### PR TITLE
Security groups

### DIFF
--- a/CHANGELOG/0.0.2.md
+++ b/CHANGELOG/0.0.2.md
@@ -10,6 +10,7 @@
 * [#1676](https://github.com/epiphany-platform/epiphany/issues/1676) - Initial automatic tests for AWS basic infrastructure module
 * [#6](https://github.com/epiphany-platform/m-aws-basic-infrastructure/issues/6) - Allow creation of additional subnets
 * [#20](https://github.com/epiphany-platform/m-aws-basic-infrastructure/issues/20) - AWS VPC needs to be fully HA for production environments
+* [#33](https://github.com/epiphany-platform/m-aws-basic-infrastructure/issues/33) - Create rules to open communication between created machines
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ or directly using Docker:
 
 * Passing complex structures as a parameter value
 
-  It is possible that you need to pass a complex structure parameter value, such as `M_SUBNETS or M_SECURITY_GROUPS, it
-  can be achieved by 2 ways:
+  It is possible that you need to pass a complex structure parameter value, such as `M_SUBNETS` or `M_SECURITY_GROUPS`,
+  it can be achieved by 2 ways:
 
     1. Changing `defaults.mk` and building new Docker image with another default value
     2. Passing it as usual with a long string:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Epiphany Module: AWS Basic Infrastructure
 
-AwsBI module is reponsible for providing basic cloud resources (eg. resource groups, virtual networks, subnets, virtual machines etc.) which will be used by upcoming modules.
+AwsBI module is reponsible for providing basic cloud resources (eg. resource groups, virtual networks, subnets, virtual
+machines etc.) which will be used by upcoming modules.
 
 # Basic usage
 
@@ -47,8 +48,8 @@ or directly using Docker:
   docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsbi:latest init M_VMS_COUNT=2 M_PUBLIC_IPS=true M_NAME=epiphany-modules-awsbi
   ```
 
-  This command will create configuration file of AwsBI module in /tmp/shared/awsbi/awsbi-config.yml. You can investigate what is stored in that file.
-  Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
+  This command will create configuration file of AwsBI module in /tmp/shared/awsbi/awsbi-config.yml. You can investigate
+  what is stored in that file. Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
 
 * Plan and apply AwsBI module:
 
@@ -57,15 +58,39 @@ or directly using Docker:
   docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsbi:latest apply M_AWS_ACCESS_KEY=xxx M_AWS_SECRET_KEY=xxx
   ```
 
-  Running those commands should create a bunch of AWS resources (resource group, vpc, subnet, ec2 instances and so on). 
+  Running those commands should create a bunch of AWS resources (resource group, vpc, subnet, ec2 instances and so on).
   You can verify it in AWS Management Console.
+
+* Passing complex structures as a parameter value
+
+  It is possible that you need to pass a complex structure parameter value, such as `M_SUBNETS or M_SECURITY_GROUPS, it
+  can be achieved by 2 ways:
+
+    1. Changing `defaults.mk` and building new Docker image with another default value
+    2. Passing it as usual with a long string:
+
+    ```shell
+    docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsbi:0.0.1 init \
+      M_VMS_COUNT=2 \
+      M_PUBLIC_IPS=true \
+      M_NAME=epiphany-modules-awsbi \
+      M_REGION=eu-west-3 \
+      M_SECURITY_GROUPS='[ { name: default_sg, rules: { ingress: [ { protocol: "-1", from_port: 0, to_port: 0, cidr_blocks: ["10.1.0.0/20"] }, { protocol: "tcp", from_port: 22, to_port: 22, cidr_blocks: ["0.0.0.0/0"] }, { protocol: "tcp", from_port: 443, to_port: 443, cidr_blocks: ["0.0.0.0/0"] } ], egress: [ { protocol: "-1", from_port: 0, to_port: 0, cidr_blocks: ["0.0.0.0/0"] } ] } } ]'
+    ```
+
+* Destroy created infrastructure
+
+  ```shell
+  docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsbi:latest plan-destroy M_AWS_ACCESS_KEY=xxx M_AWS_SECRET_KEY=xxx
+  docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsbi:latest destroy M_AWS_ACCESS_KEY=xxx M_AWS_SECRET_KEY=xxx
+  ```
 
 ## Run module with provided example
 
 ### Prepare config file
 
-Prepare your own variables in vars.mk file to use in the building process.
-Sample file (examples/basic_flow/vars.mk.sample):
+Prepare your own variables in vars.mk file to use in the building process. Sample file (
+examples/basic_flow/vars.mk.sample):
 
   ```shell
   AWS_ACCESS_KEY_ID = "xxx"
@@ -128,6 +153,7 @@ The output from this module is:
 ## Integration tests execution
 
 Prior to run integration tests on for AWS module specify variables on OS where you want to run tests:
+
 - AWS_ACCESS_KEY_ID - this is your access key
 - AWS_SECRET_ACCESS_KEY - this is your secret
 - AWSBI_IMAGE_TAG - this is full tag of docker image that you want to test e.g. "epiphanyplatform/awsbi:0.0.1"

--- a/docs/INPUTS.adoc
+++ b/docs/INPUTS.adoc
@@ -33,6 +33,36 @@ to be created. Attached into subnets with round-robin
 |no |init |Defines number of public and private subnets
 that are created in available AZs with round-robin
 
+|M_SECURITY_GROUPS |map
+|
+[source]
+----
+[
+  {
+    name: default_sg,
+    rules: {
+      ingress: [
+        {
+          protocol: "-1",
+          from_port: 0,
+          to_port: 0,
+          cidr_blocks: ["0.0.0.0/0"]
+        }
+      ],
+      egress: [
+      	{
+          protocol: "-1",
+          from_port: 0,
+          to_port: 0,
+          cidr_blocks: ["0.0.0.0/0"]
+        }
+      ]
+    }
+  }
+]
+----
+|no |init |Defines the list of security groups to attach virtual machines to
+
 |M_NAME |string |epiphany |no |init |Name to be used on all resources
 as a prefix
 

--- a/docs/INPUTS.adoc
+++ b/docs/INPUTS.adoc
@@ -52,6 +52,12 @@ that are created in specified or any available AZs
           protocol: "-1",
           from_port: 0,
           to_port: 0,
+          cidr_blocks: ["10.1.0.0/20"]
+        },
+        {
+          protocol: "tcp",
+          from_port: 22,
+          to_port: 22,
           cidr_blocks: ["0.0.0.0/0"]
         }
       ],

--- a/resources/defaults.mk
+++ b/resources/defaults.mk
@@ -9,10 +9,37 @@ define _M_SUBNETS
 }
 endef
 
+define _M_SECURITY_GROUPS
+[
+  {
+    name: default_sg,
+    rules: {
+      ingress: [
+        {
+          protocol: "-1",
+          from_port: 0,
+          to_port: 0,
+          cidr_blocks: ["0.0.0.0/0"]
+        }
+      ],
+      egress: [
+        {
+          protocol: "-1",
+          from_port: 0,
+          to_port: 0,
+          cidr_blocks: ["0.0.0.0/0"]
+        }
+      ]
+    }
+  }
+]
+endef
+
 M_VMS_COUNT ?= 1
 M_PUBLIC_IPS ?= false
 M_NAT_GATEWAY_COUNT ?= 1
 M_SUBNETS ?= $(_M_SUBNETS)
+M_SECURITY_GROUPS ?= $(_M_SECURITY_GROUPS)
 M_REGION ?= eu-central-1
 M_NAME ?= epiphany
 M_VMS_RSA ?= vms_rsa

--- a/resources/defaults.mk
+++ b/resources/defaults.mk
@@ -25,6 +25,12 @@ define _M_SECURITY_GROUPS
           protocol: "-1",
           from_port: 0,
           to_port: 0,
+          cidr_blocks: ["10.1.0.0/20"]
+        },
+        {
+          protocol: "tcp",
+          from_port: 22,
+          to_port: 22,
           cidr_blocks: ["0.0.0.0/0"]
         }
       ],

--- a/resources/templates.mk
+++ b/resources/templates.mk
@@ -18,6 +18,7 @@ $(M_MODULE_SHORT):
   use_public_ip: $(M_PUBLIC_IPS)
   nat_gateway_count: $(M_NAT_GATEWAY_COUNT)
   subnets: $(M_SUBNETS)
+  security_groups: $(M_SECURITY_GROUPS)
   rsa_pub_path: "$(M_SHARED)/$(M_VMS_RSA).pub"
   os: $(M_OS)
 endef

--- a/resources/terraform/main.tf
+++ b/resources/terraform/main.tf
@@ -14,6 +14,7 @@ module "ec2" {
   use_public_ip     = var.use_public_ip
   nat_gateway_count = var.nat_gateway_count
   subnets           = var.subnets
+  security_groups   = var.security_groups
   region            = var.region
   key_name          = aws_key_pair.kp.key_name
   os                = var.os

--- a/resources/terraform/modules/ec2/main.tf
+++ b/resources/terraform/modules/ec2/main.tf
@@ -53,9 +53,7 @@ resource "aws_instance" "awsbi" {
     volume_size = var.root_volume_size
   }
 
-  vpc_security_group_ids = [
-    aws_security_group.awsbi_security_group.id
-  ]
+  vpc_security_group_ids = aws_security_group.awsbi_security_group.*.id
 
   tags = {
     Name = "${var.name}-instance${count.index}"

--- a/resources/terraform/modules/ec2/variables.tf
+++ b/resources/terraform/modules/ec2/variables.tf
@@ -61,6 +61,27 @@ variable "subnets" {
   }
 }
 
+variable "security_groups" {
+  description = "Security groups configuration"
+  type        = list(object({
+    name        = string
+    rules       = object({
+      ingress = list(object({
+        protocol    = string
+        from_port   = number
+        to_port     = number
+        cidr_blocks = list(string)
+      }))
+      egress = list(object({
+        protocol    = string
+        from_port   = number
+        to_port     = number
+        cidr_blocks = list(string)
+      }))
+    })
+  }))
+}
+
 variable "os" {
   description = "Operating System to launch"
   type = string

--- a/resources/terraform/variables.tf
+++ b/resources/terraform/variables.tf
@@ -31,7 +31,7 @@ variable "nat_gateway_count" {
 
 variable "subnets" {
   description = "Subnets configuration"
-  type = object({
+  type        = object({
     private = object({
       count = number
     })
@@ -39,6 +39,27 @@ variable "subnets" {
       count = number
     })
   })
+}
+
+variable "security_groups" {
+  description = "Security groups configuration"
+  type        = list(object({
+    name        = string
+    rules       = object({
+      ingress = list(object({
+        protocol    = string
+        from_port   = number
+        to_port     = number
+        cidr_blocks = list(string)
+      }))
+      egress = list(object({
+        protocol    = string
+        from_port   = number
+        to_port     = number
+        cidr_blocks = list(string)
+      }))
+    })
+  }))
 }
 
 variable "rsa_pub_path" {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -30,7 +30,7 @@ const (
 	awsTagName  = "resource_group"
 	awsTagValue = "bi-module"
 	moduleName  = "bi-module"
-	awsRegion   = "eu-central-1"
+	awsRegion   = "eu-west-3"
 	sshKeyName  = "vms_rsa"
 	retries     = 30
 )
@@ -64,7 +64,7 @@ func TestOnInitWithDefaultsShouldCreateProperFileAndFolder(t *testing.T) {
 	expectedFileContentRegexp := "kind: state\nawsbi:\n  status: initialized"
 
 	// when
-	_, stderr := runDocker(t, "init", "M_NAME="+moduleName)
+	_, stderr := runDocker(t, "init", "M_NAME="+moduleName, "M_REGION="+awsRegion)
 
 	if stderr.Len() > 0 {
 		t.Fatal("There was an error during executing a command. ", string(stderr.Bytes()))


### PR DESCRIPTION
Need to discuss:
* Should be default security group so open? 
* What should be the default value for security groups?
* Do we need examples how to pass security groups to a module?
* Is it necessary to pass a name in a variable for `aws_security_group` resource?
* Is suggested format ok now or it should be extended with additional available [parameters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group), such as `ipv6_cidr_blocks`?